### PR TITLE
Bug fix

### DIFF
--- a/App.js
+++ b/App.js
@@ -13,7 +13,7 @@ import analytics from '@segment/analytics-react-native';
 
 
 analytics
-  .setup('ilrQLGpSKvTLr1iuBuKjSH3wwBD7RDOh', {
+  .setup('<enter your write key', {
     // using: [Firebase],
     flushAt: 1,
     debug: true,

--- a/App.js
+++ b/App.js
@@ -17,7 +17,8 @@ analytics
     // using: [Firebase],
     flushAt: 1,
     debug: true,
-    recordScreenViews: true,
+    // if recordScreenViews is set to true then clicking on input fields triggers screen calls - SDK may be tracking some sort of 'new' screen that is created behind the scenes
+    recordScreenViews: false,
     trackAppLifecycleEvents: true,
     trackAttributionData: true,
 


### PR DESCRIPTION
If recordScreenViews is set to true then clicking on input fields triggers screen calls - SDK may be tracking some sort of 'new' screen that is created behind the scenes